### PR TITLE
fix: Clean cache and dont run apk upgrade

### DIFF
--- a/Dockerfile-frontend
+++ b/Dockerfile-frontend
@@ -45,7 +45,7 @@ RUN du -sh ./node_modules/* | sort -nr | grep '\dM.*'
 FROM node:20-alpine as runner
 ENV NODE_ENV=production
 
-RUN apk update && apk upgrade && apk add curl vips-cpp
+RUN apk update && apk add --no-cache curl vips-cpp && rm -rf /var/cache/apk/*
 
 COPY --from=builder /usr/src/app/dist /app/dist
 COPY --from=builder /usr/src/app/node_modules /app/node_modules
@@ -57,4 +57,5 @@ HEALTHCHECK --interval=60s --start-period=10s --retries=2 --timeout=10s CMD curl
 USER node
 EXPOSE 1234
 WORKDIR /app
-CMD exec node dist/js/server.js
+
+CMD ["node", "dist/js/server.js"]


### PR DESCRIPTION
For several reasons its not adviceable to run ```upgrade``` on the runner step. Also the cache was not cleaned.

Both changes will reduce the image size.